### PR TITLE
🧪 [testing improvement] Add tests for dream categorization logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint ",
     "preview": "vite preview",
-    "test": "node --experimental-strip-types --test src/**/*.test.ts"
+    "test": "node --experimental-strip-types --test tests/**/*.test.ts"
   },
   "dependencies": {
     "html2canvas": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint ",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --experimental-strip-types --test src/**/*.test.ts"
   },
   "dependencies": {
     "html2canvas": "^1.4.1",

--- a/src/utils/dreamCategorizer.test.ts
+++ b/src/utils/dreamCategorizer.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { categorizeDream } from './dreamCategorizer.ts';
+
+test('dreamCategorizer: Serene when serene keywords dominate', () => {
+  const result = categorizeDream('I felt so peace and calm in a beautiful garden.');
+  assert.strictEqual(result, 'Serene');
+});
+
+test('dreamCategorizer: Nightmare when nightmare keywords dominate', () => {
+  const result = categorizeDream('A monster was chasing me in the dark, I felt such terror.');
+  assert.strictEqual(result, 'Nightmare');
+});
+
+test('dreamCategorizer: Epic when epic keywords dominate', () => {
+  const result = categorizeDream('An epic adventure where a hero fights a dragon with a magic sword.');
+  assert.strictEqual(result, 'Epic');
+});
+
+test('dreamCategorizer: Strange when no keywords match', () => {
+  const result = categorizeDream('I was eating a sandwich while sitting on a giant purple floating toaster.');
+  assert.strictEqual(result, 'Strange');
+});
+
+test('dreamCategorizer: empty content as Strange', () => {
+  const result = categorizeDream('');
+  assert.strictEqual(result, 'Strange');
+});
+
+test('dreamCategorizer priority: Nightmare over others', () => {
+  // 3 nightmare: fear, nightmare, dark
+  // 2 serene: peace, calm
+  // 1 epic: adventure
+  const result = categorizeDream('It was a nightmare adventure in the dark fear, despite some peace and calm.');
+  assert.strictEqual(result, 'Nightmare');
+});
+
+test('dreamCategorizer priority: Epic over Serene', () => {
+  // 3 epic: battle, adventure, hero
+  // 2 serene: peace, love
+  // 1 nightmare: fear
+  const result = categorizeDream('A battle adventure hero, filled with peace and love, but a bit of fear.');
+  assert.strictEqual(result, 'Epic');
+});
+
+test('dreamCategorizer priority: Serene fallback', () => {
+  // 1 serene: peace
+  // 1 nightmare: fear
+  // 1 epic: adventure
+  const result = categorizeDream('peace fear adventure');
+  assert.strictEqual(result, 'Serene');
+});

--- a/tests/dreamCategorizer.test.ts
+++ b/tests/dreamCategorizer.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { categorizeDream } from './dreamCategorizer.ts';
+import { categorizeDream } from '../src/utils/dreamCategorizer.ts';
 
 test('dreamCategorizer: Serene when serene keywords dominate', () => {
   const result = categorizeDream('I felt so peace and calm in a beautiful garden.');

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,5 +22,6 @@
     "noUncheckedSideEffectImports": true,
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for dream categorization logic has been addressed.
📊 **Coverage:** Scenarios now tested include:
- Correct categorization for 'Serene', 'Nightmare', and 'Epic' based on keywords.
- Fallback to 'Strange' for content with no matching keywords.
- Handling of empty content.
- Verification of priority logic when multiple categories have matching keywords.
✨ **Result:** Significant improvement in test coverage for core utility logic using a lightweight, native testing approach suitable for the environment.

---
*PR created automatically by Jules for task [33694064199541018](https://jules.google.com/task/33694064199541018) started by @harryneopotter*